### PR TITLE
Adjust ship density colors

### DIFF
--- a/main.py
+++ b/main.py
@@ -9,7 +9,7 @@ from pyarrow import csv
 import fastapi
 import pandas as pd
 from pandas.core.frame import DataFrame
-from colorcet import bmw, coolwarm, fire, CET_L18
+from colorcet import bmw, coolwarm, fire
 from datashader import transfer_functions as tf
 from datashader.utils import lnglat_to_meters
 from fastapi import FastAPI, Response
@@ -51,7 +51,9 @@ def generateatile(zoom, x, y):
     agg = csv.points(frame, 'X', 'Y')
     # The image is created from the aggregate object, a color map and aggregation function.
     # Then the object is assighed to a bytestream and returned
-    img = tf.shade(agg, cmap=CET_L18, how='log')
+    # Use a 3-colour gradient that shifts from blue to yellow and then red.
+    # Histogram equalisation helps accentuate changes at low zoom levels.
+    img = tf.shade(agg, cmap=["#0000FF", "#FFFF00", "#FF0000"], how='eq_hist')
     img_io = img.to_bytesio('PNG')
     img_io.seek(0)
     bytes = img_io.read()


### PR DESCRIPTION
## Summary
- modify Python tile shading to shift from blue to red with histogram equalization

## Testing
- `cargo test --manifest-path rust/Cargo.toml`
- `python -m py_compile main.py`


------
https://chatgpt.com/codex/tasks/task_e_68444e8becc48323a49097d4be08843f